### PR TITLE
Remove hardcoded references to "shpanRegistry" artifact registry.

### DIFF
--- a/ui/nui/src/module-development/js/stores/dev-wizard-store.js
+++ b/ui/nui/src/module-development/js/stores/dev-wizard-store.js
@@ -322,7 +322,8 @@ var DevWizardStore = Reflux.createStore({
 		const appServices = dataFromTopology.appServices;
 		const dataServices = dataFromTopology.dataServices;
 		const appServicesConfig = this.state.config.configuration.appServiceConfigurations;
-		const dataServicesConfig = this.state.config.configuration.dataServiceConfigurations;
+	        const dataServicesConfig = this.state.config.configuration.dataServiceConfigurations;
+	        const artifactRegistry = Object.keys(appServicesConfig[0].supportedVersions)[0];
 
 		let parsedAppServices = {};
 		let parsedDataServices = {};
@@ -334,7 +335,7 @@ var DevWizardStore = Reflux.createStore({
 				space: this.state.config.selectedSpace,
 				enabled: appService.isActive,
 				imageVersion: appService.version,
-				artifactRegistryName: 'shpanRegistry'
+                                artifactRegistryName: artifactRegistry
 			};
 		});
 

--- a/ui/nui/src/shared-components/js/topology/plans-selection/_plans-selection-home.comp.js
+++ b/ui/nui/src/shared-components/js/topology/plans-selection/_plans-selection-home.comp.js
@@ -104,8 +104,8 @@ class PlansSelectionHome extends React.Component{
     const position = this.props.position;
     const componentType = this.props.selectedElement.componentType;
     const style = {top: position.top, left: position.left};
-    const registry = 'shpanRegistry';
     const versions = selectedConfig ? selectedConfig.supportedVersions : null;
+    const registry = versions ? Object.keys(versions)[0] : null;
     const supportedVersions = versions ? versions[registry] : null;
 
     return(


### PR DESCRIPTION
Remove two hardcoded references to ""shpanRegistry" which prevents:
1) The GUI from displaying the version of the application available from the configured artifactory if named anything other than sphanRegistry 

2) The application from deploying under the same circumstances.

I've run through the following tests on PCF and the UI behaved as expected:
* No change to the default registry name - all apps deployed fine
* Deleted default registry name and added a new unique registry name - spring-music deployed fine, versions available in the GUI
* Deleted the registry so none are configured. GUI gave appropriate error message
* Put in a bogus registry URL first and added a second entry with the correct URL. spring-music deployed fine, versions available in the GUI
* Deployed on minikube with a customer deployer specifying ocopeaRegistry as the docker registry name.  GUI properly displayed versions of let's chat and the mongo plans, as well as successfully deployed the application.